### PR TITLE
Remove cron

### DIFF
--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -5,8 +5,8 @@ on:
     paths:
       - tobuild.txt
       - packages.json
-  schedule:
-    - cron: '*/30 * * * *'
+  # schedule:
+  #   - cron: '*/30 * * * *'
 
 jobs:
   getlistformatrix:


### PR DESCRIPTION
This is stuck in a loop. It would need to be updated with the fix that lets it unstuck itself. I am deleting the intermediary libraries for space, but will leave the arm64 binaries, although we should rebuild them for the new version at this point anyway.